### PR TITLE
Fix docker-compose and schema.prisma

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     ports:
       - "3307:3306"
     volumes:
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
       - db_data:/var/lib/mysql
 
 volumes:

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model Author {
-  author_id   BigInt @id @default(autoincrement())
+  author_id   Int    @id @default(autoincrement())
   name_author String @db.VarChar(100)
   books       Book[]
 
@@ -25,9 +25,9 @@ model Book {
   book_file    String? @db.VarChar(255)
   language     String? @db.VarChar(20)
   authors      String? @db.VarChar(100)
-  author_id    BigInt?
-  publisher_id BigInt?
-  category_id  BigInt?
+  author_id    Int?
+  publisher_id Int?
+  category_id  Int?
 
   author    Author?    @relation(fields: [author_id], references: [author_id], onDelete: Restrict, map: "books_ibfk_1")
   publisher Publisher? @relation(fields: [publisher_id], references: [publisher_id], onDelete: Restrict, map: "books_ibfk_2")
@@ -41,7 +41,7 @@ model Book {
 }
 
 model Category {
-  category_id       BigInt  @id @default(autoincrement())
+  category_id       Int     @id @default(autoincrement())
   name_category     String  @db.VarChar(30)
   subtopic_category String? @db.VarChar(30)
   books             Book[]
@@ -50,8 +50,8 @@ model Category {
 }
 
 model History {
-  history_id    BigInt    @id @default(autoincrement())
-  loan_id       BigInt?
+  history_id    Int       @id @default(autoincrement())
+  loan_id       Int?
   date_feedback DateTime? @db.Date
   feedback      String?   @db.VarChar(255)
   loan          Loan?     @relation(fields: [loan_id], references: [loan_id], onDelete: Cascade, map: "histories_ibfk_1")
@@ -61,10 +61,10 @@ model History {
 }
 
 model Loan {
-  loan_id     BigInt    @id @default(autoincrement())
+  loan_id     Int       @id @default(autoincrement())
   loan_date   DateTime? @db.Date
   return_date DateTime? @db.Date
-  user_id     BigInt?
+  user_id     Int?
   isbn        String?   @db.VarChar(13)
 
   histories History[]
@@ -77,7 +77,7 @@ model Loan {
 }
 
 model Publisher {
-  publisher_id   BigInt  @id
+  publisher_id   Int     @id
   name_publisher String  @db.VarChar(100)
   address        String? @db.VarChar(100)
   city           String? @db.VarChar(40)
@@ -93,7 +93,7 @@ model Publisher {
 }
 
 model User {
-  user_id           BigInt    @id @default(autoincrement())
+  user_id           Int       @id @default(autoincrement())
   user_name         String    @db.VarChar(30)
   user_surname      String?   @db.VarChar(60)
   dni               String?   @unique(map: "dni") @db.VarChar(20)

--- a/src/prisma/seed.ts
+++ b/src/prisma/seed.ts
@@ -1,10 +1,8 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { Prisma } from "../configuration/prisma.configuration";
 
 async function main() {
   // Publishers
-  await prisma.publisher.createMany({
+  await Prisma.publisher.createMany({
     data: [
       {
         publisher_id: 1001,
@@ -43,7 +41,7 @@ async function main() {
   });
 
   // Categories
-  await prisma.category.createMany({
+  await Prisma.category.createMany({
     data: [
       {
         name_category: "Ciencia Ficción",
@@ -60,7 +58,7 @@ async function main() {
   });
 
   // Users
-  await prisma.user.createMany({
+  await Prisma.user.createMany({
     data: [
       {
         user_name: "Laura",
@@ -101,7 +99,7 @@ async function main() {
   });
 
   // Authors
-  await prisma.author.createMany({
+  await Prisma.author.createMany({
     data: [
       { name_author: "Isaac Asimov" },
       { name_author: "Ursula K. Le Guin" },
@@ -117,7 +115,7 @@ async function main() {
   });
 
   // Books
-  await prisma.book.createMany({
+  await Prisma.book.createMany({
     data: [
       {
         isbn: "9780000000001",
@@ -150,7 +148,7 @@ async function main() {
   });
 
   // Loans
-  await prisma.loan.createMany({
+  await Prisma.loan.createMany({
     data: [
       {
         loan_date: new Date("2025-06-01"),
@@ -178,5 +176,5 @@ main()
     process.exit(1);
   })
   .finally(async () => {
-    await prisma.$disconnect();
+    await Prisma.$disconnect();
   });


### PR DESCRIPTION
This branch fix Prisma & Docker error caused by modifications in the infrastructure.
The changes are:

**Prisma Schema:** Changed `BigInt` types to `Int`.
**Use of Prisma Client:** In the file `src/prisma/seed.ts`, now we use the `Prisma` object from the file `src/configuration/prisma.configuration.ts` instead of creating a new instance of PrismaClient.
**Docker Compose:** Removed use of the file `init.sql` in the file `docker-compose.yml`.