### PR TITLE
[HU-BE08] Create get publisher by name endpoint

### DIFF
--- a/src/controllers/publishers.controller.ts
+++ b/src/controllers/publishers.controller.ts
@@ -16,4 +16,24 @@ export class PublishersController {
 
     response.status(200).json(success(publisherOutDTO));
   }
+
+  static async getByName(request: Request, response: Response): Promise<void> {
+    const name = request.params.name || request.query.name;
+
+    if (Array.isArray(name)) {
+      throw new BadRequestError("Multiple names not allowed");
+    }
+    
+    if (typeof name !== "string" || name.trim().length === 0) {
+      throw new BadRequestError("Name is missing");
+    }
+
+    if (!/^[a-zA-Z\s]+$/.test(name)) {
+      throw new BadRequestError("Name can only contain characters and spaces");
+    }
+
+    const publishersOutDTO = await PublishersService.getByName(name);
+
+    response.status(200).json(success(publishersOutDTO));
+  }
 }

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -9,6 +9,8 @@ paths:
     $ref: "./paths/get-author-by-name.path.yaml"
   /publishers/{id}:
     $ref: "./paths/get-publisher-by-id.path.yaml"
+  /publishers/name/{name}:
+    $ref: "./paths/get-publisher-by-name.path.yaml"
 components:
   schemas:
     Author:

--- a/src/documentation/paths/get-publisher-by-name.path.yaml
+++ b/src/documentation/paths/get-publisher-by-name.path.yaml
@@ -1,0 +1,52 @@
+get:
+  tags:
+    - Publishers
+  summary: Get publisher by name
+  parameters:
+    - name: name
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Publisher found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/publisher.component.yaml#/PublisherResponse"
+    "400":
+      description: Bad Request - Invalid name parameter
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error.component.yaml#/Error"
+          examples:
+            missingName:
+              summary: Name is missing
+              value:
+                error: Name is missing
+                timestamp: "30/09/2025, 20:46:04"
+            invalidName:
+              summary: Name can only contain characters and spaces
+              value:
+                error: Name can only contain characters and spaces
+                timestamp: "30/09/2025, 20:46:04"
+            multipleNames:
+              summary: Multiple names not allowed
+              value:
+                error: Multiple names not allowed
+                timestamp: "30/09/2025, 20:46:04"
+    "404":
+      description: Publisher not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error.component.yaml#/Error"
+          examples:
+            notFound:
+              summary: Publisher not found
+              value:
+                error: No publisher found with name
+
+

--- a/src/repositories/publishers.repository.ts
+++ b/src/repositories/publishers.repository.ts
@@ -5,4 +5,14 @@ export class PublishersRepository {
     static async getById(id: number): Promise<Publisher | null> {
         return await Prisma.publisher.findUnique({ where: { publisher_id: id}});
     }
+
+    static async getByName(name: string): Promise<Publisher[]> {
+        return await Prisma.publisher.findMany({
+            where: {
+                name_publisher: {
+                    contains: name,
+                },
+            },
+        });
+    }
 }

--- a/src/routes/publishers.routes.ts
+++ b/src/routes/publishers.routes.ts
@@ -3,4 +3,7 @@ import { PublishersController } from "../controllers/publishers.controller";
 
 export const PublishersRoutes = Router();
 
-PublishersRoutes.get("/:id", PublishersController.getById);
+PublishersRoutes.get("/id/:id", PublishersController.getById);
+
+PublishersRoutes.get("/name/:name", PublishersController.getByName);
+PublishersRoutes.get("/name", PublishersController.getByName);

--- a/src/services/publishers.service.ts
+++ b/src/services/publishers.service.ts
@@ -24,4 +24,24 @@ export class PublishersService {
 
     return dto;
   }
+
+  static async getByName(name: string): Promise<PublisherOutDTO[]> {
+    const publishers = await PublishersRepository.getByName(name);
+
+    if (!publishers || publishers.length === 0) {
+      throw new NotFoundError(`No publisher found with name: ${name}`);
+    }
+
+    return publishers.map(publisher => ({
+      publisher_id: publisher.publisher_id,
+      name_publisher: publisher.name_publisher,
+      address: publisher.address ?? undefined,
+      city: publisher.city ?? undefined,
+      province: publisher.province ?? undefined,
+      postal_code: publisher.postal_code ?? undefined,
+      country: publisher.country ?? undefined,
+      phone: publisher.phone ?? undefined,
+      notes: publisher.notes ?? undefined,
+    }));
+  }
 }


### PR DESCRIPTION
##  This branch adds the `GET /publishers/name/:name` endpoint

### Changes included

- Implemented the `GET /publishers/name/:name` endpoint.
- Returns **HTTP 200** with the publisher or list of publishers if the request is successful.
- Returns **HTTP 404** with the message:  
  `"No publisher found with name: <name>"`  
  if no matching publisher exists.
- Returns **HTTP 400** with the message:  
  `"Name can only contain characters and spaces"`  
  if the `name` parameter contains invalid characters.
- Returns **HTTP 400** with the message:  
  `"Name is missing"`  
  when accessing `/publishers/name` or `/publishers/name/?` without a valid name.
- Returns **HTTP 400** with the message:  
  `"Multiple names not allowed"`  
  if the request sends an array instead of a single name.
- Uses the standardized error handling system.
- Maintains proper separation of concerns between **controllers**, **services**, and **repositories**.
- Includes corresponding Swagger documentation

