### PR TITLE
[HU-BE06] Create get all publishers endpoint

### DIFF
--- a/src/controllers/publishers.controller.ts
+++ b/src/controllers/publishers.controller.ts
@@ -36,4 +36,10 @@ export class PublishersController {
 
     response.status(200).json(success(publishersOutDTO));
   }
+
+  static async getAll(request: Request, response: Response): Promise<void> {
+    const publisherOutDto = await PublishersService.getAll();
+
+    response.status(200).json(success(publisherOutDto));
+  }
 }

--- a/src/documentation/components/author.component.yaml
+++ b/src/documentation/components/author.component.yaml
@@ -24,7 +24,6 @@ AuthorsResponse:
       type: array
       items:
         $ref: "#/Author"
-        $ref: "#/Author"
     timestamp:
       type: string
       example: "25/09/2025, 17:41:33"

--- a/src/documentation/components/publisher.component.yaml
+++ b/src/documentation/components/publisher.component.yaml
@@ -37,3 +37,14 @@ PublisherResponse:
     timestamp:
       type: string
       example: "26/09/2025, 19:45:00"
+PublishersResponse:
+  type: object
+  properties:
+    data:
+      type: array
+      items:
+        $ref: "#/Publisher"
+    timestamp:
+      type: string
+      example: "02/10/2025, 21:52:56"
+

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -13,6 +13,8 @@ paths:
     $ref: "./paths/get-publisher-by-id.path.yaml"
   /publishers/name/{name}:
     $ref: "./paths/get-publisher-by-name.path.yaml"
+  /publishers:
+    $ref: "./paths/get-all-publishers.path.yaml"
 components:
   schemas:
     Author:

--- a/src/documentation/paths/get-all-publishers.path.yaml
+++ b/src/documentation/paths/get-all-publishers.path.yaml
@@ -1,0 +1,50 @@
+get:
+  tags:
+    - Publishers
+  summary: Get all publishers
+  responses:
+    "200":
+      description: List of publishers
+      content:
+        application/json:
+          schema:
+            $ref: "../components/publisher.component.yaml#/PublishersResponse"
+          example:
+            data:
+              - publisher_id: 1001
+                name_publisher: Nova Editorial
+                address: Calle Luna 12
+                city: Madrid
+                province: Madrid
+                postal_code: "28001"
+                country: España
+                phone: "912345678"
+                notes: Activo
+              - publisher_id: 1002
+                name_publisher: Ediciones Solaris
+                address: Av. Estelar 45
+                city: Barcelona
+                province: Cataluña
+                postal_code: "08002"
+                country: España
+                phone: "934567890"
+                notes: Empresa cerrada en 2023
+              - publisher_id: 1003
+                name_publisher: Tinta Libre
+                address: Plaza del Saber 3
+                city: Valencia
+                province: Valencia
+                postal_code: "46001"
+                country: España
+                phone: "963258741"
+                notes: Activo
+            timestamp: "02/10/2025, 21:52:56"
+    "404":
+      description: No publishers found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error.component.yaml#/Error"
+          example:
+            error: There are no records in Publishers
+            timestamp: "02/10/2025, 21:52:56"

--- a/src/repositories/publishers.repository.ts
+++ b/src/repositories/publishers.repository.ts
@@ -15,4 +15,8 @@ export class PublishersRepository {
             },
         });
     }
+
+    static async getAll(): Promise<Publisher[]> {
+        return await Prisma.publisher.findMany();
+    }
 }

--- a/src/routes/publishers.routes.ts
+++ b/src/routes/publishers.routes.ts
@@ -7,3 +7,5 @@ PublishersRoutes.get("/id/:id", PublishersController.getById);
 
 PublishersRoutes.get("/name/:name", PublishersController.getByName);
 PublishersRoutes.get("/name", PublishersController.getByName);
+
+PublishersRoutes.get("/", PublishersController.getAll);

--- a/src/services/publishers.service.ts
+++ b/src/services/publishers.service.ts
@@ -44,4 +44,26 @@ export class PublishersService {
       notes: publisher.notes ?? undefined,
     }));
   }
+
+  static async getAll(): Promise<PublisherOutDTO[]> {
+    const publishers = await PublishersRepository.getAll();
+
+    if (publishers.length === 0) {
+      throw new NotFoundError(`There are no records in Publishers`);
+    }
+
+    const dto: PublisherOutDTO[] = publishers.map((publisher) => ({
+      publisher_id: publisher.publisher_id,
+      name_publisher: publisher.name_publisher,
+      address: publisher.address ?? undefined,
+      city: publisher.city ?? undefined,
+      province: publisher.province ?? undefined,
+      postal_code: publisher.postal_code ?? undefined,
+      country: publisher.country ?? undefined,
+      phone: publisher.phone ?? undefined,
+      notes: publisher.notes ?? undefined,
+    }));
+
+    return dto;
+  }
 }


### PR DESCRIPTION
### 📖 Description

Implements the `GET /publishers` endpoint to retrieve all publisher records. This feature supports frontend display needs and follows the project's architecture and standardized error handling.

###  Tasks Completed

- Implemented `getAll()` method in:
  - `PublishersRepository`
  - `PublishersService`
  - `PublishersController`
- Returns:
  - `HTTP 200` with a list of publishers
  - `HTTP 404` with message `"There are no records in Publishers"` if none exist
- Integrated `NotFoundError` for consistent error handling
- Added OpenAPI documentation:
  - `get-all-publishers.path.yaml`
  - `PublishersResponse` schema in `publisher.component.yaml`
  - Linked path in `main.documentation.yaml`
- Reviewed a teammate’s pull request