### PR TITLE
Implementation of [HU-BE09]  GET /categories and [HU-BE10] GET /categories/id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "class-validator-jsonschema": "^5.1.0",
+        "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "joi": "^18.0.1",
         "jsonwebtoken": "^9.0.2",
@@ -744,6 +745,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/c12/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1003,10 +1017,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "class-validator-jsonschema": "^5.1.0",
+    "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "joi": "^18.0.1",
     "jsonwebtoken": "^9.0.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { errorHandlerMiddleware } from "./middlewares/error-handler.middleware";
 import { PublishersRoutes } from "./routes/publishers.routes";
 import { AuthorsRoutes } from "./routes/authors.routes";
 import { AuthRoutes } from "./routes/auth.routes";
+import { CategoriesRoutes } from "./routes/categories.routes";
 
 const documentationPath = "./src/documentation/main.documentation.yaml";
 const app = express();
@@ -16,6 +17,7 @@ SwaggerParser.dereference(documentationPath).then((document) => {
   app.use("/auth", AuthRoutes);
   app.use("/authors", AuthorsRoutes);
   app.use("/publishers", PublishersRoutes);
+  app.use("/categories", CategoriesRoutes);
   app.use(errorHandlerMiddleware());
 
   app.listen(PORT, () => {

--- a/src/controllers/categories.controller.ts
+++ b/src/controllers/categories.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { BadRequestError } from "../models/errors/bad-request.error";
+import { CategoriesService } from "../services/categories.service";
+import { success } from "../utilities/success.utility";
+
+export class CategoriesController {
+    static async getById(request: Request, response: Response): Promise<void> {
+        const { id } = request.params;
+        const categoryId = parseInt(id, 10);
+
+        if (isNaN(categoryId) || categoryId <= 0) {
+            throw new BadRequestError("Invalid ID for Category");
+        }
+
+        const categoryOutDto = await CategoriesService.getById(categoryId);
+
+        response.status(200).json(success(categoryOutDto));
+    }
+
+    static async getAll(_request: Request, response: Response): Promise<void> {
+        const categoryOutDto = await CategoriesService.getAll();
+
+        response.status(200).json(success(categoryOutDto));
+    }
+}

--- a/src/documentation/components/category.component.yaml
+++ b/src/documentation/components/category.component.yaml
@@ -1,0 +1,12 @@
+Category:
+  type: object
+  properties:
+    categoryId:
+      type: integer
+      example: 1
+    nameCategory:
+      type: string
+      example: Ciencia Ficción
+    subtopicCategory:
+      type: string
+      example: Viajes Espaciales

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -17,6 +17,12 @@ paths:
     $ref: "./paths/get-all-publishers.path.yaml"
   /auth/register:
     $ref: "./paths/register.path.yaml"
+  /categories:
+    $ref: "./paths/get-all-categories.path.yaml"
+  /categories/id/{id}:
+    $ref: "./paths/get-category-by-id.path.yaml"
+
+
 components:
   schemas:
     ErrorResponse:
@@ -37,3 +43,6 @@ components:
       $ref: "./components/register-in-dto.component.yaml#/RegisterInDTO"
     UserOutDTO:
       $ref: "./components/user-out-dto.component.yaml#/UserOutDTO"
+    Category:
+      $ref: "./components/category.component.yaml#/Category"
+

--- a/src/documentation/paths/get-all-categories.path.yaml
+++ b/src/documentation/paths/get-all-categories.path.yaml
@@ -1,0 +1,27 @@
+get:
+  tags:
+    - Categories
+  summary: Get all categories
+  responses:
+    "200":
+      description: List of categories
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../components/data-response.component.yaml#/DataResponse"
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "../components/category.component.yaml#/Category"
+    "404":
+      description: No categories found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: There are no records in Categories
+            timestamp: "08/10/2025, 19:35:53"

--- a/src/documentation/paths/get-category-by-id.path.yaml
+++ b/src/documentation/paths/get-category-by-id.path.yaml
@@ -1,0 +1,40 @@
+get:
+  tags:
+    - Categories
+  summary: Get category by id
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+  responses:
+    "200":
+      description: Category
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../components/data-response.component.yaml#/DataResponse"
+              - type: object
+                properties:
+                  data:
+                    $ref: "../components/category.component.yaml#/Category"
+    "400":
+      description: Invalid ID
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: Invalid Id for Category
+            timestamp: "2025-10-08T20:26:00Z"
+    "404":
+      description: Category not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: Category with id 123 not found
+            timestamp: "2025-10-08T20:26:00Z"

--- a/src/dtos/out/category.dto.ts
+++ b/src/dtos/out/category.dto.ts
@@ -1,0 +1,13 @@
+import { IsNumber, IsString, IsOptional} from "class-validator";
+
+export class CategoryOutDto {
+    @IsNumber()
+    categoryId: number;
+
+    @IsString()
+    nameCategory: string;
+
+    @IsOptional()
+    @IsString()
+    subtopicCategory?: string | null;
+}

--- a/src/repositories/categories.repository.ts
+++ b/src/repositories/categories.repository.ts
@@ -1,0 +1,13 @@
+import { Category } from "@prisma/client";
+import { prisma } from "../configuration/prisma.configuration";
+
+export class CategoryRepository {
+    static async getById(id: number): Promise<Category | null> {
+        return await prisma.category.findUnique({ where: {categoryId: id } });
+    }
+
+    static async getAll(): Promise<Category[]> {
+        return await prisma.category.findMany();
+    }
+
+}

--- a/src/routes/categories.routes.ts
+++ b/src/routes/categories.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { CategoriesController } from "../controllers/categories.controller";
+import { dtoValidationMiddleware } from "../middlewares/dto-validation.middleware";
+
+export const CategoriesRoutes = Router();
+
+CategoriesRoutes.get("/id/:id", CategoriesController.getById);
+
+CategoriesRoutes.get("/", CategoriesController.getAll);

--- a/src/services/categories.service.ts
+++ b/src/services/categories.service.ts
@@ -1,0 +1,34 @@
+import { Category } from "@prisma/client";
+import { CategoryOutDto } from "../dtos/out/category.dto";
+import { NotFoundError } from "../models/errors/not-found.error";
+import { CategoryRepository } from "../repositories/categories.repository";
+
+export class CategoriesService {
+    static async getById(id: number): Promise<CategoryOutDto> {
+        const category = await CategoryRepository.getById(id);
+
+        if (!category) {
+            throw new NotFoundError(`Category with id ${id} not found`);
+        }
+
+        return {
+            categoryId: category.categoryId,
+            nameCategory: category.nameCategory,
+            subtopicCategory: category.subtopicCategory,
+        };
+    }
+
+    static async getAll(): Promise<CategoryOutDto[]> {
+        const categories = await CategoryRepository.getAll();
+
+        if (!categories || categories.length === 0) {
+            throw new NotFoundError(`There are no records in Categories`);
+        }
+
+        return categories.map((category) => ({
+            categoryId: category.categoryId,
+            nameCategory: category.nameCategory,
+            subtopicCategory: category.subtopicCategory,
+        }));
+    }
+}


### PR DESCRIPTION
### Pull Request Description

This PR implements the endpoints `GET /categories` and `GET /categories/id/{id}` as defined in user stories [HU-BE09] and [HU-BE10].  
It includes full logic across layers (controller, service, repository), standardized error handling, and corresponding Swagger documentation.

- `GET /categories`: returns all categories or a 404 error if no records are found.  
- `GET /categories/id/{id}`: returns a category by ID or a 404 error if it doesn't exist.  
- Parameter validation and separation of concerns are maintained.  
- `main.documentation.yaml` updated and new path/component files created.