### PR TITLE
[HU-BE19] Add Auth middleware

### DIFF
--- a/src/documentation/components/login-in-dto.component.yaml
+++ b/src/documentation/components/login-in-dto.component.yaml
@@ -7,7 +7,7 @@ LoginInDTO:
       example: "jhon-doe@email.com"
     password:
       type: string
-      example: "securePassword123"
+      example: "SECUREpassword123!"
   required:
     - email
     - password

--- a/src/documentation/components/register-in-dto.component.yaml
+++ b/src/documentation/components/register-in-dto.component.yaml
@@ -33,7 +33,7 @@ RegisterInDTO:
       example: "jhon-doe@email.com"
     password:
       type: string
-      example: "securePassword123"
+      example: "SECUREpassword123!"
     fullname:
       type: string
       example: "Jhon Doe"

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -24,6 +24,11 @@ paths:
   /categories/id/{id}:
     $ref: "./paths/get-category-by-id.path.yaml"
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     ErrorResponse:
       $ref: "./components/error-response.component.yaml#/ErrorResponse"
@@ -47,4 +52,3 @@ components:
       $ref: "./components/user-out-dto.component.yaml#/UserOutDTO"
     Category:
       $ref: "./components/category.component.yaml#/Category"
-

--- a/src/documentation/paths/login.path.yaml
+++ b/src/documentation/paths/login.path.yaml
@@ -1,7 +1,7 @@
 post:
   tags:
     - Auth
-  summary: Login 
+  summary: Login
   requestBody:
     required: true
     content:
@@ -34,6 +34,15 @@ post:
           example:
             error: User not found
             timestamp: 2025-10-03T21:45:00.000Z
+    "401":
+      description: User is inactive
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: User is inactive
+            timestamp: 2025-10-03T21:45:00.000Z
     "400":
       description: Invalid credentials
       content:
@@ -43,4 +52,3 @@ post:
           example:
             error: Invalid credentials
             timestamp: 2025-10-03T21:45:00.000Z
-              

--- a/src/dtos/in/register.dto.ts
+++ b/src/dtos/in/register.dto.ts
@@ -4,6 +4,7 @@ import {
   IsPhoneNumber,
   IsPostalCode,
   IsString,
+  IsStrongPassword,
   MaxLength,
 } from "class-validator";
 
@@ -45,7 +46,12 @@ export class RegisterInDto {
   @MaxLength(120)
   email: string;
 
-  @IsString()
+  @IsStrongPassword({
+    minLength: 8,
+    minLowercase: 2,
+    minUppercase: 2,
+    minNumbers: 1,
+  })
   @MaxLength(25)
   password: string;
 

--- a/src/dtos/in/register.dto.ts
+++ b/src/dtos/in/register.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsEmail,
+  IsNotEmpty,
   IsOptional,
   IsPhoneNumber,
   IsPostalCode,
@@ -16,27 +17,27 @@ export class RegisterInDto {
   @IsString()
   @IsOptional()
   @MaxLength(100)
-  address: string | null;
+  address?: string;
 
   @IsString()
   @IsOptional()
   @MaxLength(40)
-  city: string | null;
+  city?: string;
 
   @IsString()
   @IsOptional()
   @MaxLength(30)
-  province: string | null;
+  province?: string;
 
   @IsPostalCode("any")
   @IsOptional()
   @MaxLength(20)
-  postalCode: string | null;
+  postalCode?: string;
 
   @IsString()
   @IsOptional()
   @MaxLength(30)
-  country: string | null;
+  country?: string;
 
   @IsPhoneNumber()
   @MaxLength(50)
@@ -56,6 +57,7 @@ export class RegisterInDto {
   password: string;
 
   @IsString()
+  @IsNotEmpty()
   @MaxLength(100)
   fullname: string;
 }

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -6,12 +6,20 @@ import { AuthService } from "../services/auth.service";
 
 export function authMiddleware() {
   return async (request: Request, _response: Response, next: NextFunction) => {
-    const token = getTokenFrom(request);
+    const authorizationHeader = request.headers.authorization;
 
-    if (!token) throw new UnauthorizedError("No token provided");
+    if (!authorizationHeader) throw new UnauthorizedError("No token provided");
+
+    const token = getTokenFrom(authorizationHeader);
+
+    if (!token) throw new UnauthorizedError("Malformed token");
 
     try {
       const payload = AuthService.getPayloadOf(token);
+
+      if (!payload.sub || !payload.role) {
+        throw new UnauthorizedError("Invalid token payload");
+      }
 
       request.user = { id: payload.sub, role: payload.role };
 

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,26 +1,28 @@
-import { Response, Request, NextFunction } from "express";
-import jwt, { TokenExpiredError } from "jsonwebtoken";
-import { JWT_SECRET } from "../configuration/env.configuration";
 import { UnauthorizedError } from "../models/errors/unauthorized.error";
-import { JWTUser } from "../models/jwt-user.model";
+import { JsonWebTokenError, TokenExpiredError } from "jsonwebtoken";
+import { getTokenFrom } from "../utilities/get-token-from.utility";
+import { Response, Request, NextFunction } from "express";
+import { AuthService } from "../services/auth.service";
 
 export function authMiddleware() {
   return async (request: Request, _response: Response, next: NextFunction) => {
-    const authorizationHeader = request.headers.authorization;
+    const token = getTokenFrom(request);
 
-    if (!authorizationHeader) throw new UnauthorizedError("No token provided");
-
-    const token = authorizationHeader.split(" ")[1];
+    if (!token) throw new UnauthorizedError("No token provided");
 
     try {
-      const decodedToken = jwt.verify(token, JWT_SECRET) as JWTUser;
+      const payload = AuthService.getPayloadOf(token);
 
-      request.user = { id: decodedToken.id, role: decodedToken.role };
+      request.user = { id: payload.sub, role: payload.role };
 
       next();
     } catch (error) {
       if (error instanceof TokenExpiredError) {
         throw new UnauthorizedError("Token expired");
+      }
+
+      if (error instanceof JsonWebTokenError) {
+        throw new UnauthorizedError("Malformed token");
       }
 
       throw new UnauthorizedError("Invalid token");

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,0 +1,29 @@
+import { Response, Request, NextFunction } from "express";
+import jwt, { TokenExpiredError } from "jsonwebtoken";
+import { JWT_SECRET } from "../configuration/env.configuration";
+import { UnauthorizedError } from "../models/errors/unauthorized.error";
+import { JWTUser } from "../models/jwt-user.model";
+
+export function authMiddleware() {
+  return async (request: Request, _response: Response, next: NextFunction) => {
+    const authorizationHeader = request.headers.authorization;
+
+    if (!authorizationHeader) throw new UnauthorizedError("No token provided");
+
+    const token = authorizationHeader.split(" ")[1];
+
+    try {
+      const decodedToken = jwt.verify(token, JWT_SECRET) as JWTUser;
+
+      request.user = { id: decodedToken.id, role: decodedToken.role };
+
+      next();
+    } catch (error) {
+      if (error instanceof TokenExpiredError) {
+        throw new UnauthorizedError("Token expired");
+      }
+
+      throw new UnauthorizedError("Invalid token");
+    }
+  };
+}

--- a/src/models/authenticated-request.model.ts
+++ b/src/models/authenticated-request.model.ts
@@ -1,0 +1,6 @@
+import { Request } from "express";
+import { JWTUser } from "./jwt-user.model";
+
+export interface AuthenticatedRequest extends Request {
+  user: JWTUser;
+}

--- a/src/models/authorization-token-payload.model.ts
+++ b/src/models/authorization-token-payload.model.ts
@@ -1,0 +1,7 @@
+import { UserRole } from "@prisma/client";
+import { JwtPayload } from "jsonwebtoken";
+
+export type AuthorizationTokenPayload = JwtPayload & {
+  sub: number;
+  role: UserRole;
+};

--- a/src/models/errors/unauthorized.error.ts
+++ b/src/models/errors/unauthorized.error.ts
@@ -1,0 +1,7 @@
+import { CustomError } from "./custom-error.error";
+
+export class UnauthorizedError extends CustomError {
+  constructor(value?: any) {
+    super(value || "Unauthorized", 401);
+  }
+}

--- a/src/models/express.d.ts
+++ b/src/models/express.d.ts
@@ -1,0 +1,11 @@
+import { UserRole } from "@prisma/client";
+import { JWTUser } from "./jwt-user.model";
+import "express";
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JWTUser;
+    }
+  }
+}

--- a/src/models/jwt-user.model.ts
+++ b/src/models/jwt-user.model.ts
@@ -1,0 +1,6 @@
+import { UserRole } from "@prisma/client";
+
+export type JWTUser = {
+  id: number;
+  role: UserRole;
+};

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -102,7 +102,7 @@ model User {
   email            String   @unique() @db.VarChar(120)
   password         String   @db.VarChar(255)
   registrationDate DateTime @default(now()) @map("registration_date")
-  userDrop         Boolean  @default(true) @map("user_drop")
+  userDrop         Boolean  @default(false) @map("user_drop")
   daysDisciplinary Int      @default(0) @map("days_disciplinary")
   role             UserRole @default(USER)
   fullname         String   @db.VarChar(100)

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,3 +1,4 @@
+import { User } from "@prisma/client";
 import { JWT_SECRET, SALT_ROUNDS } from "../configuration/env.configuration";
 import { LoginInDto } from "../dtos/in/login.dto";
 import { RegisterInDto } from "../dtos/in/register.dto";
@@ -10,8 +11,10 @@ import bcrypt, { compare } from "bcrypt";
 import jwt from "jsonwebtoken";
 
 export class AuthService {
-  static getAuthorization(userId: number): string {
-    return jwt.sign({ userId }, JWT_SECRET, { expiresIn: "1h" });
+  static getAuthorization(user: User): string {
+    return jwt.sign({ id: user.userId, role: user.role }, JWT_SECRET, {
+      expiresIn: "1h",
+    });
   }
 
   static async hash(value: string): Promise<string> {
@@ -55,7 +58,7 @@ export class AuthService {
       userId: newUser.userId,
     };
 
-    const authorization = this.getAuthorization(newUser.userId);
+    const authorization = this.getAuthorization(newUser);
 
     return { user: userOutDto, authorization };
   }
@@ -69,7 +72,7 @@ export class AuthService {
 
     if (!passwordsMatches) throw new BadRequestError("Invalid credentials");
 
-    const token = this.getAuthorization(user.userId);
+    const token = this.getAuthorization(user);
     const userOutDto: UserOutDTO = {
       fullname: user.fullname,
       registrationDate: user.registrationDate.toISOString(),

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -23,10 +23,6 @@ export class AuthService {
   static getPayloadOf(token: string): AuthorizationTokenPayload {
     const payload = jwt.verify(token, JWT_SECRET) as AuthorizationTokenPayload;
 
-    if (!payload.sub || !payload.role) {
-      throw new UnauthorizedError("Invalid token payload");
-    }
-
     return payload;
   }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -9,12 +9,25 @@ import { NotFoundError } from "../models/errors/not-found.error";
 import { UsersRepository } from "../repositories/users.repository";
 import bcrypt, { compare } from "bcrypt";
 import jwt from "jsonwebtoken";
+import { AuthorizationTokenPayload } from "../models/authorization-token-payload.model";
+import { UnauthorizedError } from "../models/errors/unauthorized.error";
 
 export class AuthService {
   static getAuthorization(user: User): string {
-    return jwt.sign({ id: user.userId, role: user.role }, JWT_SECRET, {
-      expiresIn: "1h",
-    });
+    const expiresIn = "1h";
+    const payload = { sub: user.userId, role: user.role };
+
+    return jwt.sign(payload, JWT_SECRET, { expiresIn });
+  }
+
+  static getPayloadOf(token: string): AuthorizationTokenPayload {
+    const payload = jwt.verify(token, JWT_SECRET) as AuthorizationTokenPayload;
+
+    if (!payload.sub || !payload.role) {
+      throw new UnauthorizedError("Invalid token payload");
+    }
+
+    return payload;
   }
 
   static async hash(value: string): Promise<string> {
@@ -67,6 +80,8 @@ export class AuthService {
     const user = await UsersRepository.getByEmail(data.email);
 
     if (!user) throw new NotFoundError("User not found");
+
+    if (user.userDrop) throw new UnauthorizedError("User is inactive");
 
     const passwordsMatches = await compare(data.password, user.password);
 

--- a/src/utilities/get-token-from.utility.ts
+++ b/src/utilities/get-token-from.utility.ts
@@ -1,7 +1,5 @@
-import { Request } from "express";
-
-export function getTokenFrom(request: Request): string | undefined {
-  const [type, token] = request.headers.authorization?.split(" ") ?? [];
+export function getTokenFrom(header: string): string | undefined {
+  const [type, token] = header?.split(" ") ?? [];
   const isBearerToken = type === "Bearer";
 
   return isBearerToken ? token : undefined;

--- a/src/utilities/get-token-from.utility.ts
+++ b/src/utilities/get-token-from.utility.ts
@@ -1,0 +1,8 @@
+import { Request } from "express";
+
+export function getTokenFrom(request: Request): string | undefined {
+  const [type, token] = request.headers.authorization?.split(" ") ?? [];
+  const isBearerToken = type === "Bearer";
+
+  return isBearerToken ? token : undefined;
+}


### PR DESCRIPTION
This branch adds the auth middleware to protect specific endpoints, requiring to be logged to access them.

## Changes
- **Auth Middleware:** Added file `src/middlewares/auth.middleware.ts`.
- **Authenticated Request:** Added `AuthenticatedRequest` model to represent a request made by an authorized user, to be used in controllers.
- **Unauthorized Error:** Added `UnauthorizedError` model, with HTTP Code 401.
- **Express types:** Added `express.d.ts` file to indicate Express how the `request.user` property should be.
- **JWTUser:** Added `JWTUser` model to represent the data inside the decoded authorization token.
- **Documentation:** Added security scheme to `main.documentation.yaml` to add to SwaggerUI the "Authorize" input.

## Note
To allow Swagger use the authorization header in the requests, you have to put this in the `.path` file of the endpoint you want to protect:
```yaml
security:
  BearerAuth: []
```

To use the `authMiddleware`, you use it as any other middleware in the endpoint you want to protect:
```typescript
ExampleRoutes.post("/", authMiddleware(), ExampleController.protectedAction);
```