### PR TITLE
[HU-BE22] Create PUT /publishers

### DIFF
--- a/src/controllers/publishers.controller.ts
+++ b/src/controllers/publishers.controller.ts
@@ -51,4 +51,20 @@ export class PublishersController {
 
     response.status(201).json(success(createdPublisher));
   }
+
+  static async update(request: Request, response: Response): Promise<void> {
+    const { id } =request.params;
+    const publisherId = parseInt(id, 10);
+
+    if (isNaN(publisherId) || publisherId <= 0) {
+      throw new BadRequestError("Invalid ID for Publisher");
+    }
+
+    const dto = request.body as CreatePublisherDto;
+
+    const updatedPublisher = await PublishersService.update(publisherId, dto);
+
+    response.status(200).json(success(updatedPublisher));
+  }
+  
 }

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -19,7 +19,8 @@ paths:
     $ref: "./paths/get-publisher-by-name.path.yaml"
   /publishers/create:
     $ref: "./paths/create-publisher.path.yaml"
-
+  /publishers/update/id/{id}:
+    $ref: "./paths/update-publisher.path.yaml"
 
   /auth/register:
     $ref: "./paths/register.path.yaml"

--- a/src/documentation/paths/update-publisher.path.yaml
+++ b/src/documentation/paths/update-publisher.path.yaml
@@ -1,0 +1,53 @@
+put:
+  tags:
+    - Publishers
+  summary: Update an existing publisher by ID
+  description: Updates the name and/or country of a publisher. Requires a valid numeric ID.
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: Numeric ID of the publisher to update
+      schema:
+        type: integer
+        minimum: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../components/create-publisher-dto.component.yaml#/CreatePublisherDto"
+        example:
+          namePublisher: "Updated Publisher Name"
+          countryPublisher: "Updated Country"
+  responses:
+    '200':
+      description: Publisher successfully updated
+      content:
+        application/json:
+          schema:
+            $ref: "../components/data-response.component.yaml#/DataResponse"
+          example:
+            success: true
+            data:
+              id: 1
+              namePublisher: "Updated Publisher Name"
+              countryPublisher: "Updated Country"
+    '400':
+      description: Invalid ID or malformed input
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+    '404':
+      description: Publisher not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+    '500':
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"

--- a/src/dtos/in/publisher.dto.ts
+++ b/src/dtos/in/publisher.dto.ts
@@ -43,3 +43,44 @@ export class CreatePublisherDto {
   @MaxLength(255)
   notes?: string;
 }
+
+export class UpdatePublisherDto {
+  @IsString()
+  @MaxLength(100)
+  namePublisher: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(40)
+  city?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  province?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  postalCode?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  country?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(16)
+  phone?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  notes?: string;
+}

--- a/src/repositories/publishers.repository.ts
+++ b/src/repositories/publishers.repository.ts
@@ -36,4 +36,20 @@ export class PublishersRepository {
       },
     });
   }
+
+  static async update(id: number, data: CreatePublisherDto): Promise<Publisher> {
+    return await prisma.publisher.update({
+      where: { publisherId: id},
+      data: {
+        namePublisher: data.namePublisher,
+        address: data.address,
+        city: data.city,
+        province: data.province,
+        postalCode: data.postalCode,
+        country: data.country,
+        phone: data.phone,
+        notes: data.notes,
+      },
+    });
+  }
 }

--- a/src/routes/publishers.routes.ts
+++ b/src/routes/publishers.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { PublishersController } from "../controllers/publishers.controller";
 import { dtoValidationMiddleware } from "../middlewares/dto-validation.middleware";
-import { CreatePublisherDto } from "../dtos/in/publisher.dto";
+import { CreatePublisherDto, UpdatePublisherDto } from "../dtos/in/publisher.dto";
 
 export const PublishersRoutes = Router();
 
@@ -12,3 +12,5 @@ PublishersRoutes.get("/name/:name", PublishersController.getByName);
 PublishersRoutes.get("/", PublishersController.getAll);
 
 PublishersRoutes.post("/", dtoValidationMiddleware(CreatePublisherDto), PublishersController.create);
+
+PublishersRoutes.put("/id/:id", dtoValidationMiddleware(UpdatePublisherDto), PublishersController.update);

--- a/src/services/publishers.service.ts
+++ b/src/services/publishers.service.ts
@@ -77,4 +77,31 @@ export class PublishersService {
         throw new InternalServerError("Failed to create publisher");
     }
   }
+
+  static async update(id: number, data: CreatePublisherDto): Promise<PublisherOutDTO> {
+    const existing = await PublishersRepository.getById(id);
+
+    if (!existing) {
+      throw new NotFoundError(`Publisher with id ${id} not found`);
+    }
+
+    try {
+      const updated = await PublishersRepository.update(id, data);
+
+      return {
+        publisherId: updated.publisherId,
+        namePublisher: updated.namePublisher,
+        address: updated.address,
+        city: updated.city,
+        province: updated.province,
+        postalCode: updated.postalCode,
+        country: updated.country,
+        phone: updated.phone,
+        notes: updated.notes,
+      };
+    } catch (error) {
+      throw new InternalServerError("Failed to update publisher");
+    }
+  }
+
 }


### PR DESCRIPTION
## 📌 Summary

This pull request implements the `PUT /publishers/id/:id` endpoint, allowing updates to an existing publisher by ID. It includes input validation, error handling, and Swagger documentation.

---

##  What’s Included

- **Route**: `PUT /publishers/id/:id`
- **Purpose**: Update one or both fields of a publisher (`namePublisher`, `countryPublisher`)
- **Input DTO**: `UpdatePublisherDto`
- **Output DTO**: `PublisherOutDto`

###  Validations

- `id` must be a positive integer (`parseInt`, `isNaN`, `> 0`)
- `namePublisher`: optional
- `countryPublisher`: optional

### ❗ Error Handling

- `400 BadRequest`: invalid ID or malformed input
- `404 NotFound`: publisher not found
- `500 InternalServerError`: update operation failed

---

## 📚 Swagger Documentation

- Added Swagger path entry: `PUT /publishers/id/{id}`
- Includes:
  - Valid request example
  - Typed response using `PublisherOutDto`
  - Error responses for 400, 404, and 500
- File: `paths/update-publisher.path.yaml`
- Referenced in: `main.documentation.yaml`

---
