### PR TITLE
[HU-BE23] DELETE /publishers [HU-BE24] DELETE /categories

### DIFF
--- a/src/controllers/categories.controller.ts
+++ b/src/controllers/categories.controller.ts
@@ -63,4 +63,17 @@ export class CategoriesController {
         response.status(200).json(success(updatedCategory));
     }
 
+    static async delete(request: Request, response: Response): Promise<void> {
+        const { id } = request.params;
+        const categoryId = parseInt(id, 10);
+
+        if (isNaN(categoryId) || categoryId <= 0) {
+            throw new BadRequestError("Invalid ID for category");
+        }
+
+        const existing = await CategoriesService.delete(categoryId);
+
+        response.status(200).json(success(existing));
+  }
+
 }

--- a/src/controllers/publishers.controller.ts
+++ b/src/controllers/publishers.controller.ts
@@ -66,5 +66,18 @@ export class PublishersController {
 
     response.status(200).json(success(updatedPublisher));
   }
+
+  static async delete(request: Request, response: Response): Promise<void> {
+    const { id } = request.params;
+    const publisherId = parseInt(id, 10);
+
+    if (isNaN(publisherId) || publisherId <= 0) {
+      throw new BadRequestError("Invalid ID for publisher");
+    }
+
+    const existing = await PublishersService.delete(publisherId);
+
+    response.status(200).json(success(existing));
+  }
   
 }

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -21,6 +21,9 @@ paths:
     $ref: "./paths/create-publisher.path.yaml"
   /publishers/update/id/{id}:
     $ref: "./paths/update-publisher.path.yaml"
+  /publishers/delete/id/{id}:
+    $ref: "./paths/delete-publisher.path.yaml"
+
 
   /auth/register:
     $ref: "./paths/register.path.yaml"
@@ -37,6 +40,8 @@ paths:
     $ref: "./paths/create-category.path.yaml"
   /categories/update/id/{id}:
     $ref: "./paths/update-category.path.yaml"
+  /categories/delete/id/{id}:
+    $ref: "./paths/delete-category.path.yaml"
 
 
 components:

--- a/src/documentation/paths/delete-category.path.yaml
+++ b/src/documentation/paths/delete-category.path.yaml
@@ -1,0 +1,56 @@
+delete:
+  tags:
+    - Categories
+  summary: Delete a category by ID
+  description: Deletes a category by its numeric ID. Returns success if the category was deleted. Throws error if the ID is invalid or the category does not exist.
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: Numeric ID of the category to delete
+      schema:
+        type: integer
+        minimum: 1
+  responses:
+    '200':
+      description: Category successfully deleted
+      content:
+        application/json:
+          schema:
+            $ref: "../components/data-response.component.yaml#/DataResponse"
+          example:
+            data: true
+            timestamp: "25/09/2025, 17:41:33"
+    '400':
+      description: Invalid ID format
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Invalid ID for category"
+              code: 400
+            timestamp: "25/09/2025, 17:41:33"
+    '404':
+      description: Category not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Category with ID 123 not found"
+              code: 404
+            timestamp: "25/09/2025, 17:41:33"
+    '500':
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Failed to delete category"
+              code: 500
+            timestamp: "25/09/2025, 17:41:33"

--- a/src/documentation/paths/delete-publisher.path.yaml
+++ b/src/documentation/paths/delete-publisher.path.yaml
@@ -1,0 +1,56 @@
+delete:
+  tags:
+    - Publishers
+  summary: Delete a publisher by ID
+  description: Deletes a publisher by its numeric ID. Returns success if the publisher was deleted. Throws error if the ID is invalid or the publisher does not exist.
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: Numeric ID of the publisher to delete
+      schema:
+        type: integer
+        minimum: 1
+  responses:
+    '200':
+      description: Publisher successfully deleted
+      content:
+        application/json:
+          schema:
+            $ref: "../components/data-response.component.yaml#/DataResponse"
+          example:
+            data: true
+            timestamp: "25/09/2025, 17:41:33"
+    '400':
+      description: Invalid ID format
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Invalid ID for publisher"
+              code: 400
+            timestamp: "25/09/2025, 17:41:33"
+    '404':
+      description: Publisher not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Publisher with ID 123 not found"
+              code: 404
+            timestamp: "25/09/2025, 17:41:33"
+    '500':
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Failed to delete publisher"
+              code: 500
+            timestamp: "25/09/2025, 17:41:33"

--- a/src/repositories/categories.repository.ts
+++ b/src/repositories/categories.repository.ts
@@ -41,4 +41,8 @@ export class CategoryRepository {
             },
         });
     }
+
+    static async delete(id: number): Promise<{ count: number }> {
+        return await prisma.category.deleteMany({ where: { categoryId: id } });
+    }
 }

--- a/src/repositories/publishers.repository.ts
+++ b/src/repositories/publishers.repository.ts
@@ -52,4 +52,9 @@ export class PublishersRepository {
       },
     });
   }
+
+  static async delete(id: number): Promise<{ count: number }> {
+    return await prisma.publisher.deleteMany({ where: { publisherId: id } });
+  }
+
 }

--- a/src/routes/categories.routes.ts
+++ b/src/routes/categories.routes.ts
@@ -14,3 +14,5 @@ CategoriesRoutes.get("/name/:name", CategoriesController.getByName);
 CategoriesRoutes.post("/", dtoValidationMiddleware(CreateCategoryDto), CategoriesController.create);
 
 CategoriesRoutes.put("/id/:id", dtoValidationMiddleware(UpdateCategoryDto), CategoriesController.update);
+
+CategoriesRoutes.delete("/id/:id", CategoriesController.delete);

--- a/src/routes/publishers.routes.ts
+++ b/src/routes/publishers.routes.ts
@@ -14,3 +14,5 @@ PublishersRoutes.get("/", PublishersController.getAll);
 PublishersRoutes.post("/", dtoValidationMiddleware(CreatePublisherDto), PublishersController.create);
 
 PublishersRoutes.put("/id/:id", dtoValidationMiddleware(UpdatePublisherDto), PublishersController.update);
+
+PublishersRoutes.delete("/id/:id", PublishersController.delete);

--- a/src/services/categories.service.ts
+++ b/src/services/categories.service.ts
@@ -57,23 +57,39 @@ export class CategoriesService {
     }
 
     static async update(id: number, data: CreateCategoryDto): Promise<CategoryOutDto> {
-    const existing = await CategoryRepository.getById(id);
+        const existing = await CategoryRepository.getById(id);
 
-    if (!existing) {
-        throw new NotFoundError(`Category with id ${id} not found`);
+        if (!existing) {
+            throw new NotFoundError(`Category with id ${id} not found`);
+        }
+
+        try {
+            const updated = await CategoryRepository.update(id, data);
+
+            return {
+                categoryId: updated.categoryId,
+                nameCategory: updated.nameCategory,
+                subtopicCategory: updated.subtopicCategory,
+            };
+        } catch (error) {
+            throw new InternalServerError("Failed to update category");
+        }
     }
 
-    try {
-        const updated = await CategoryRepository.update(id, data);
+    static async delete(id: number): Promise<boolean> {
+        try {
+            const result = await CategoryRepository.delete(id);
 
-        return {
-            categoryId: updated.categoryId,
-            nameCategory: updated.nameCategory,
-            subtopicCategory: updated.subtopicCategory,
-        };
-    } catch (error) {
-        throw new InternalServerError("Failed to update category");
+            if (result.count === 0) {
+                throw new NotFoundError(`Category with ID ${id} not found`);
+            }
+
+            return true;
+        } catch (error: any){
+            if (error instanceof NotFoundError) {
+                throw error;
+            }
+            throw new InternalServerError("Failed to delete category, {cause: error}");
+        } 
     }
-}
-
 }

--- a/src/services/publishers.service.ts
+++ b/src/services/publishers.service.ts
@@ -104,4 +104,21 @@ export class PublishersService {
     }
   }
 
+  static async delete(id: number): Promise<boolean> {
+    try {
+      const result = await PublishersRepository.delete(id);
+
+      if (result.count === 0) {
+        throw new NotFoundError(`Publisher with ID ${id} not found`);
+      }
+
+      return true;
+    } catch (error: any){
+      if (error instanceof NotFoundError) {
+        throw error;
+      }
+      throw new InternalServerError("Failed to delete publisher, {cause: error}");
+    } 
+  }
+
 }


### PR DESCRIPTION
## Objective

Implement DELETE routes to remove entities by ID in the Biblioteca Code Cafe backend system.

## Endpoints Added

- `DELETE /publishers/id/:id`  
- `DELETE /categories/id/:id`  

Each endpoint deletes the corresponding entity by its numeric ID and returns a boolean indicating success.

## Validations

- `id` must be a positive integer  
  - Validated using `parseInt`, `isNaN`, and `> 0`

## Expected Responses

| Status | Description           | Example Response |
|--------|-----------------------|------------------|
| 200 OK | Entity deleted        | `{ "data": true, "timestamp": "..." }` |
| 400 Bad Request | Invalid ID format | `{ "error": { "message": "Invalid ID", "code": 400 }, "timestamp": "..." }` |
| 404 Not Found | Entity not found | `{ "error": { "message": "Entity not found", "code": 404 }, "timestamp": "..." }` |
| 500 Internal Server Error | Unexpected error | `{ "error": { "message": "Failed to delete", "code": 500 }, "timestamp": "..." }` |

## Swagger Documentation

- Added:
  - `delete-publisher.path.yaml`
  - `delete-category.path.yaml`
- Includes:
  - Valid request example
  - Successful response (`true`)
  - Not found error (`404`)
  - Internal error (`500`) with message