### PR TITLE
[HU-Be28] - Implement DELETE /books/id/:id endpoint

### DIFF
--- a/src/controllers/books.controller.ts
+++ b/src/controllers/books.controller.ts
@@ -85,24 +85,19 @@ export class BooksController {
             bookFile?: Express.Multer.File[];
         };
 
-        // Validate ISBN format
         if (!isbn || !/^\d+$/.test(isbn)) {
             throw new BadRequestError("Invalid ISBN format");
         }
 
-        // Validate exist the files book
         const bookCover = files.bookCover?.[0];
         const bookFile = files.bookFile?.[0];
         if (!bookCover || !bookFile) {
             throw new BadRequestError("Both 'bookCover' and 'bookFile' must be provided");
         }
 
-        // prepare destination routes
         const bookCoverPath = `uploads/cover/${generateSafeFilename(bookCover.originalname, isbn)}`;
         const bookFilePath = `uploads/file/${generateSafeFilename(bookFile.originalname, isbn)}`;
 
-
-        // Delegate to the service layer
         const bookOutDto = await BooksService.updateFiles(isbn, {
             bookCover: bookCoverPath,
             bookFile: bookFilePath,
@@ -111,6 +106,22 @@ export class BooksController {
         });
 
         response.status(200).json(success(bookOutDto));
+    }
+
+    static async delete(request: Request, response: Response): Promise<void> {
+        const { id } = request.params;
+        
+        if (typeof id !== "string" || id.trim().length === 0) {
+            throw new BadRequestError("Isbn is missing");
+        }
+
+        if (!/^\d+$/.test(id)) {
+            throw new BadRequestError("Isbn can only contain number");
+        }
+        
+        const existing = await BooksService.delete(id);
+
+        response.status(200).json(success(existing));
     }
 
 }

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -57,6 +57,8 @@ paths:
     $ref: "./paths/update-book.path.yaml"
   /books/{isbn}/files:
     $ref: "./paths/update-book-files.path.yaml"
+  /books/delete/isbn/{id}:
+    $ref: "./paths/delete-book.path.yaml"
 
 
   /users/name/{name}:

--- a/src/documentation/paths/delete-book.path.yaml
+++ b/src/documentation/paths/delete-book.path.yaml
@@ -1,0 +1,58 @@
+delete:
+  tags:
+    - Books
+  summary: Delete a book by ISBN
+  description: >
+    Deletes a book by its ISBN. If the book has associated files (book_cover, book_file),
+    they will be deleted from the file system if present. If the files were already removed externally,
+    the service logs a warning but continues gracefully.
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: ISBN of the book to delete
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Book successfully deleted
+      content:
+        application/json:
+          schema:
+            $ref: "../components/data-response.component.yaml#/DataResponse"
+          example:
+            data: true
+            timestamp: "27/10/2025, 21:54:00"
+    '400':
+      description: Invalid ISBN format
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Invalid ISBN format"
+              code: 400
+            timestamp: "27/10/2025, 21:54:00"
+    '404':
+      description: Book not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Book with ISBN 9781234567890 not found"
+              code: 404
+            timestamp: "27/10/2025, 21:54:00"
+    '500':
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error:
+              message: "Failed to delete book"
+              code: 500
+            timestamp: "27/10/2025, 21:54:00"

--- a/src/repositories/books.repository.ts
+++ b/src/repositories/books.repository.ts
@@ -32,4 +32,9 @@ export class BooksRepository {
             data: bookData,
         });
     }
+
+    static async delete(id: string): Promise<{ count: number }> {
+        return await prisma.book.deleteMany({ where: { isbn: id } });
+    }
+    
 }

--- a/src/routes/books.routes.ts
+++ b/src/routes/books.routes.ts
@@ -20,3 +20,5 @@ BooksRoutes.post("/", dtoValidationMiddleware(CreateBookDto), BooksController.cr
 BooksRoutes.put("/isbn/:id", dtoValidationMiddleware(UpdateBookDto), BooksController.update);
 
 BooksRoutes.put("/:isbn/files", uploadBookFiles, BooksController.updateFiles);
+
+BooksRoutes.delete("/isbn/:id", BooksController.delete);

--- a/src/services/books.service.ts
+++ b/src/services/books.service.ts
@@ -197,4 +197,31 @@ export class BooksService {
             categoryId: updatedBook.categoryId ?? null,
         };
     }
+
+    static async delete(isbn: string): Promise<Boolean> {
+        try {
+            const book: Book | null = await BooksRepository.getById(isbn);
+
+            if (!book) {
+                throw new NotFoundError(`Book with isbn ${isbn} not found`);
+            }
+
+            const result = await BooksRepository.delete(isbn);
+
+            if (result.count === 0) {
+                throw new NotFoundError(`Book with isbn ${isbn} not found`);
+            }
+
+            await deleteIfExists(book.bookCover);
+            await deleteIfExists(book.bookFile);
+
+            return true;
+        } catch (error: any) {
+            if (error instanceof NotFoundError) {
+                throw error;
+            }
+            throw new InternalServerError("Failed to delete book: ${cause: error}");  
+        }
+    }
+    
 }

--- a/src/utilities/file.utility.ts
+++ b/src/utilities/file.utility.ts
@@ -1,19 +1,11 @@
 import fs from "fs/promises";
 
-/**
- * Deletes an array of file paths if they exist.
- * Logs a warning if deletion fails.
- */
 export async function deleteUploadedFiles(paths: (string | undefined)[]): Promise<void> {
   for (const path of paths) {
     await deleteIfExists(path);
   }
 }
 
-/**
- * Deletes a single file path if it exists.
- * Logs a warning if deletion fails.
- */
 export async function deleteIfExists(path: string | undefined | null): Promise<void> {
   if (!path) return;
   try {


### PR DESCRIPTION
##  Objective

Implements the `DELETE /books/isbn/:id` endpoint to remove a book by its ISBN. It also includes defensive logic to delete associated files (`book_cover`, `book_file`) if they exist.

---

##  Changes Made

- Added the `delete(isbn: string)` method in `books.service.ts`, retrieving the book first to access file paths.
- Integrated the `deleteIfExists(path)` helper from `file.utility.ts` to safely remove files.
- Preserved ISBN validation and error handling using `NotFoundError` and `InternalServerError`.
- Updated Swagger documentation (`delete-book.path.yaml`) to reflect endpoint behavior.
- Ensured the flow continues gracefully if files were previously removed outside the application.

---

##  Expected Behavior

| Case                          | Result                     | Status Code           | Notes                                 |
|------------------------------|----------------------------|------------------------|----------------------------------------|
| Book exists with files       | Book and files deleted     | `200 OK`              | Returns `true`                         |
| Book exists without files    | Book deleted               | `200 OK`              | Returns `true`                         |
| Invalid ISBN format          | Validation error           | `400 Bad Request`     | `"Invalid ISBN format"`               |
| Book not found               | Business error             | `404 Not Found`       | `"Book with ISBN ... not found"`      |
| Unexpected error             | Internal failure           | `500 Internal Server Error` | `"Failed to delete book: ..."` |

