### PR TITLE
GET all & id for loans

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import { AuthRoutes } from "./routes/auth.routes";
 import { CategoriesRoutes } from "./routes/categories.routes";
 import { BooksRoutes } from "./routes/books.routes";
 import { UsersRoutes } from "./routes/users.routes";
+import { LoansRoutes } from "./routes/loans.routes";
 
 const documentationPath = "./src/documentation/main.documentation.yaml";
 const app = express();
@@ -22,6 +23,7 @@ SwaggerParser.dereference(documentationPath).then((document) => {
   app.use("/categories", CategoriesRoutes);
   app.use("/books", BooksRoutes);
   app.use("/users", UsersRoutes);
+  app.use("/loans", LoansRoutes);
   app.use(errorHandlerMiddleware());
 
   app.listen(PORT, () => {

--- a/src/controllers/loans.controller.ts
+++ b/src/controllers/loans.controller.ts
@@ -1,0 +1,26 @@
+import { Request, response, Response } from "express";
+import { BadRequestError } from "../models/errors/bad-request.error";
+import { LoansService } from "../services/loans.service";
+import { success } from "../utilities/success.utility";
+
+export class LoansController {
+    static async getById(request: Request, response: Response): Promise<void> {
+        const { id } = request.params;
+        const loadId = parseInt(id, 10);
+
+        if (isNaN(loadId)) {
+            throw new BadRequestError("Invalid ID for loan");
+        }
+
+        const loadOutDTO = await LoansService.getById(loadId);
+
+        response.status(200).json(success(loadOutDTO));
+    }
+
+    static async getAll(_request: Request, response: Response): Promise<void> {
+        const loanOutDtos = await LoansService.getAll();
+        
+        response.status(200).json(success(loanOutDtos));
+    }
+
+}

--- a/src/documentation/components/loan.component.yaml
+++ b/src/documentation/components/loan.component.yaml
@@ -1,0 +1,22 @@
+Loan:
+  type: object
+  properties:
+    loanId:
+      type: integer
+      example: 1
+    loanDate:
+      type: string
+      format: date
+      example: "2025-06-01"
+    returnDate:
+      type: string
+      format: date
+      example: "2025-06-15"
+    userId:
+      type: integer
+      nullable: true
+      example: 2
+    isbn:
+      type: string
+      nullable: true
+      example: "9780000000002"

--- a/src/documentation/main.documentation.yaml
+++ b/src/documentation/main.documentation.yaml
@@ -67,7 +67,12 @@ paths:
     $ref: "./paths/get-user-by-id.path.yaml"
   /users:
     $ref: "./paths/get-all-users.path.yaml"
-    
+  
+  /loans:
+    $ref: "./paths/get-all-loans.path.yaml"
+  /loans/id/{id}:
+    $ref: "./paths/get-loan-by-id.path.yaml"
+
 components:
   securitySchemes:
     BearerAuth:
@@ -111,3 +116,6 @@ components:
 
     BookOutDTO:
       $ref: "./components/book-out-dto.component.yaml#/BookOutDTO"
+
+    Loan:
+      $ref: "./components/loan.component.yaml#/Loan"

--- a/src/documentation/paths/get-all-loans.path.yaml
+++ b/src/documentation/paths/get-all-loans.path.yaml
@@ -1,0 +1,27 @@
+get:
+  tags:
+    - Loans
+  summary: Get all loans
+  responses:
+    "200":
+      description: List of loans
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../components/data-response.component.yaml#/DataResponse"
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "../components/loan.component.yaml#/Loan"
+    "404":
+      description: No loans found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: No loans found
+            timestamp: "2025-10-28T21:54:00Z"

--- a/src/documentation/paths/get-loan-by-id.path.yaml
+++ b/src/documentation/paths/get-loan-by-id.path.yaml
@@ -1,0 +1,42 @@
+get:
+  tags:
+    - Loans
+  summary: Get loan by ID
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: Numeric ID of the loan
+      schema:
+        type: integer
+        minimum: 1
+  responses:
+    "200":
+      description: Loan found
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../components/data-response.component.yaml#/DataResponse"
+              - type: object
+                properties:
+                  data:
+                    $ref: "../components/loan.component.yaml#/Loan"
+    "400":
+      description: Invalid ID format
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: Invalid ID for loan
+            timestamp: "2025-10-28T21:54:00Z"
+    "404":
+      description: Loan not found
+      content:
+        application/json:
+          schema:
+            $ref: "../components/error-response.component.yaml#/ErrorResponse"
+          example:
+            error: Loan with id 123 not found
+            timestamp: "2025-10-28T21:54:00Z"

--- a/src/dtos/out/loan.dto.ts
+++ b/src/dtos/out/loan.dto.ts
@@ -1,0 +1,29 @@
+import {
+  IsNumber,
+  IsString,
+  IsOptional,
+  IsISO8601
+} from "class-validator";
+
+export class LoanOutDTO {
+
+    @IsNumber()
+    loanId: number;
+
+    @IsOptional()
+    @IsISO8601()
+    loanDate?: string | null;
+
+    @IsOptional()
+    @IsISO8601()
+    returnDate?: string | null;
+
+    @IsNumber()
+    @IsOptional()
+    userId?: number | null;
+    
+    @IsString()
+    @IsOptional()
+    isbn?: string | null;
+
+}

--- a/src/repositories/loans.repository.ts
+++ b/src/repositories/loans.repository.ts
@@ -1,0 +1,13 @@
+import { Loan } from "@prisma/client";
+import { prisma } from "../configuration/prisma.configuration";
+
+export class LoansRepository {
+    static async getById(id: number): Promise<Loan | null> {
+        return await prisma.loan.findUnique({ where: { loanId: id }      });
+    }
+
+    static async getAll(): Promise<Loan[]> {
+        return await prisma.loan.findMany();
+    }
+
+}

--- a/src/routes/loans.routes.ts
+++ b/src/routes/loans.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { LoansController } from '../controllers/loans.controller';
+
+export const LoansRoutes = Router();
+
+LoansRoutes.get('/id/:id', LoansController.getById);
+
+LoansRoutes.get('/', LoansController.getAll);

--- a/src/services/loans.service.ts
+++ b/src/services/loans.service.ts
@@ -1,0 +1,45 @@
+import { Loan } from "@prisma/client";
+import { NotFoundError } from "../models/errors/not-found.error";
+import { InternalServerError } from "../models/errors/internal-server.error";
+import { LoanOutDTO } from "../dtos/out/loan.dto";
+import { LoansRepository } from "../repositories/loans.repository";
+
+export class LoansService {
+    static async getById(id: number): Promise<LoanOutDTO> {
+        const loan = await LoansRepository.getById(id);
+
+        if (!loan) {
+            throw new NotFoundError(`Loan with id ${id} not found`);
+        }
+
+        const dto: LoanOutDTO = {
+            loanId: loan.loanId,
+            loanDate: loan.loanDate ? loan.loanDate.toISOString().split("T")[0] : null,
+            returnDate: loan.returnDate ? loan.returnDate.toISOString().split("T")[0] : null,
+            isbn: loan.isbn ?? null,
+            userId: loan.userId ?? null,
+        };
+
+        return dto;
+
+    }
+
+    static async getAll(): Promise<LoanOutDTO[]> {
+        const loans: Loan[] = await LoansRepository.getAll();
+
+        if (loans.length === 0) {
+            throw new NotFoundError("No loans found");
+        }
+
+        const dtos: LoanOutDTO[] = loans.map((loan: Loan) => ({
+            loanId: loan.loanId,
+            loanDate: loan.loanDate ? loan.loanDate.toISOString().split("T")[0] : null,
+            returnDate: loan.returnDate ? loan.returnDate.toISOString().split("T")[0] : null,
+            isbn: loan.isbn ?? null,
+            userId: loan.userId ?? null,
+        }));
+
+        return dtos;
+    }
+
+}


### PR DESCRIPTION
This PR implements the functionalities described in the following user stories:

- **[HU-BE40]**: Implements the `GET /loans` endpoint to retrieve all registered loans.  
  - Returns an array of `LoanOutDTO` objects.  
  - Responds with a 404 error if no records are found.

- **[HU-BE36]**: Implements the `GET /loans/id/:id` endpoint to retrieve a loan by its ID.  
  - Validates that the ID is numeric.  
  - Returns a `LoanOutDTO` object if found.  
  - Responds with a 400 error for invalid ID format and 404 if the loan is not found.

Both endpoints are documented in Swagger and use the `LoanOutDTO` schema to structure the response.